### PR TITLE
Add jinja2 state to fix Salt issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install Ubuntu 20.04LTS or 22.04LTS environment in a VM or on a dedicated host (
 
 BitCurator uses a standalone command-line tool for installation and upgrade. Follow the steps below to download and run it.
 
-Log in, ensure you are connected to a network, and execute the following in a terminalto ensure everything is up to date:
+Log in, ensure you are connected to a network, and execute the following in a terminal to ensure everything is up to date:
 
 ```shell
 sudo apt-get update

--- a/bitcurator/python-packages/init.sls
+++ b/bitcurator/python-packages/init.sls
@@ -1,4 +1,5 @@
 include:
+  - bitcurator.python-packages.pip
   - bitcurator.python-packages.analyzemft
   - bitcurator.python-packages.argparse
   - bitcurator.python-packages.bagit
@@ -24,11 +25,13 @@ include:
   - bitcurator.python-packages.six
   - bitcurator.python-packages.unicodecsv
   - bitcurator.python-packages.wheel
+  - bitcurator.python-packages.jinja2
 
 bitcurator-python-packages:
   test.nop:
     - name: bitcurator-python-packages
     - require:
+      - sls: bitcurator.python-packages.pip
       - sls: bitcurator.python-packages.analyzemft
       - sls: bitcurator.python-packages.argparse
       - sls: bitcurator.python-packages.bagit
@@ -54,3 +57,4 @@ bitcurator-python-packages:
       - sls: bitcurator.python-packages.six
       - sls: bitcurator.python-packages.unicodecsv
       - sls: bitcurator.python-packages.wheel
+      - sls: bitcurator.python-packages.jinja2

--- a/bitcurator/python-packages/jinja2.sls
+++ b/bitcurator/python-packages/jinja2.sls
@@ -1,0 +1,8 @@
+include:
+  - bitcurator.python-packages.pip
+
+jinja2==3.0.3:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: bitcurator.python-packages.pip

--- a/bitcurator/python-packages/pip.sls
+++ b/bitcurator/python-packages/pip.sls
@@ -1,0 +1,9 @@
+include:
+  - bitcurator.packages.python3-pip
+
+bitcurator-python-packages-pip3:
+  pip.installed:
+    - name: pip>=21.2.4
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: bitcurator.packages.python3-pip


### PR DESCRIPTION
The current version of SaltStack installs the most current version of Jinja2 during upgrade, however it is also incompatible with the current version of SaltStack. To fix this issue, this PR creates a pip state to increase the pip version and pin Jinja2 to 3.0.3.

Also fixed a minor typo in the README.