### PR TITLE
Update NSRLLookup reqs, add ewf-tools

### DIFF
--- a/bitcurator/packages/ewf-tools.sls
+++ b/bitcurator/packages/ewf-tools.sls
@@ -1,0 +1,9 @@
+include:
+  - bitcurator.packages.libewf
+  - bitcurator.packages.libewf-dev
+
+ewf-tools:
+  pkg.installed:
+    - requires:
+      - sls: bitcurator.packages.libewf
+      - sls: bitcurator.packages.libewf-dev

--- a/bitcurator/packages/init.sls
+++ b/bitcurator/packages/init.sls
@@ -25,6 +25,7 @@ include:
   - bitcurator.packages.dkms
   - bitcurator.packages.docker
   - bitcurator.packages.equivs
+  - bitcurator.packages.ewf-tools
   - bitcurator.packages.expat
   - bitcurator.packages.expect
   - bitcurator.packages.fdutils
@@ -176,6 +177,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.dkms
       - sls: bitcurator.packages.docker
       - sls: bitcurator.packages.equivs
+      - sls: bitcurator.packages.ewf-tools
       - sls: bitcurator.packages.expat
       - sls: bitcurator.packages.expect
       - sls: bitcurator.packages.fdutils

--- a/bitcurator/tools/nsrllookup.sls
+++ b/bitcurator/tools/nsrllookup.sls
@@ -2,6 +2,10 @@ include:
   - bitcurator.packages.build-essential
   - bitcurator.packages.cmake
   - bitcurator.packages.libboost-dev
+  - bitcurator.packages.libboost-filesystem-dev
+  - bitcurator.packages.libboost-program-options-dev
+  - bitcurator.packages.libboost-system-dev
+  - bitcurator.packages.libboost-test-dev
 
 nsrllookup-source:
   file.managed:
@@ -30,6 +34,10 @@ nsrllookup-build:
       - sls: bitcurator.packages.build-essential
       - sls: bitcurator.packages.cmake
       - sls: bitcurator.packages.libboost-dev
+      - sls: bitcurator.packages.libboost-filesystem-dev
+      - sls: bitcurator.packages.libboost-program-options-dev
+      - sls: bitcurator.packages.libboost-system-dev
+      - sls: bitcurator.packages.libboost-test-dev
     - unless: test -x /usr/local/bin/nsrllookup
 
 nsrllookup-cleanup:


### PR DESCRIPTION
Noticed ewf-tools was missing, and updated the requirements for nsrllookup to avoid build issues during install. These were originally noticed in the [BitCurator forum](https://groups.google.com/g/bitcurator-users/c/hyVjj1027f4).

The other items from that forum will be covered in a later discussion.