### PR TITLE
use xdg-user-dir to determine desktop path

### DIFF
--- a/bitcurator/theme/mediasymlink.sls
+++ b/bitcurator/theme/mediasymlink.sls
@@ -1,9 +1,5 @@
 {% set user = salt['pillar.get']('bitcurator_user', 'bcadmin') %}
-{% if user == "root" %}
-  {% set home = "/root" %}
-{% else %}
-  {% set home = "/home/" + user %}
-{% endif %}
+{% set desktop = salt['cmd.run']('sudo -u ' + user + ' xdg-user-dir DESKTOP') %}
 {% set all_users = salt['user.list_users']() %}
 {% if user in all_users %}
   {% set group = salt['cmd.run']('id -gn ' + user) %}
@@ -16,7 +12,7 @@ include:
 
 mediasymlink:
   file.symlink:
-    - name: {{ home }}/Desktop/Shared Folders and Media
+    - name: {{ desktop }}/Shared Folders and Media
     - target: /media
     - user: {{ user }}
     - group: {{ group }}


### PR DESCRIPTION
This adds support for different desktop languages since the Desktop folder name is localized on Linux (in contrast to Windows or macOS).

It also fixes the script for systems on which the home directories are not located under /home.