### PR TITLE
changed URL in README to .org, from .net which is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,5 +194,4 @@ The BitCurator environment is volunteer-maintained. BitCurator was originally de
 
 Community support is managed by the BitCurator Consortium. Find out more at:
 
-http://www.bitcuratorconsortium.net/
-
+https://bitcuratorconsortium.org/


### PR DESCRIPTION
www.bitcuratorconsortium.net doesn't appear to be maintained, switched to .org. 