### PR TITLE
Update siegfried repo key, update libuna

### DIFF
--- a/bitcurator/repos/siegfried.sls
+++ b/bitcurator/repos/siegfried.sls
@@ -1,7 +1,8 @@
 bitcurator-siegfried-key:
   file.managed:
     - name: /usr/share/keyrings/SIEGFRIED-PGP-KEY.asc
-    - source: salt://bitcurator/repos/files/SIEGFRIED-PGP-KEY.asc
+    - source: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x20F802FE798E6857
+    - skip_verify: True
     - makedirs: True
 
 bitcurator-siegfried-repo:

--- a/bitcurator/tools/libuna.sls
+++ b/bitcurator/tools/libuna.sls
@@ -1,5 +1,5 @@
-{% set version = '20220102' %}
-{% set hash = '349e2c40e88b1248a2766a2b67699c17b3de3b90a2ffbe63c858ef4e9fcb0694' %}
+{% set version = '20220611' %}
+{% set hash = '20791e301d768be4b61f1ef551f304d0c386c32a78efa6619fa4cafa8ab9f231' %}
 
 include:
   - bitcurator.packages.build-essential


### PR DESCRIPTION
This PR fixes the source for the siegfried repo key (sets it to pull from source instead of storing locally), and updates the hash and version for libuna. Addresses [this issue](https://groups.google.com/g/bitcurator-users/c/xs9fLS4r-M0).