### PR TITLE
Update Nautilus Scripts to use mate-search-tool

### DIFF
--- a/bitcurator/env/.local/share/nautilus/scripts/File Analysis/Calculate MD5
+++ b/bitcurator/env/.local/share/nautilus/scripts/File Analysis/Calculate MD5
@@ -51,7 +51,7 @@ if [ $filesCount == 1 ] ; then
       (md5sum "${files[0]}" > "$filename.md5") 2>&1 | zenity --progress --title "Make md5" --text "Making: $filename.md5" --pulsate --auto-close;
     elif [ "$choice" == "Display on screen" ] ; then
       md5Hash=`md5sum "$file"`;
-      zenity --entry --title "Calculate MD5 (Files and Directories)" --text="The MD5 hash of the selected file:" --entry-text="$md5Hash";
+      zenity --entry --title "Calculate MD5 (Files and Directories)" --text="The MD5 hash of the selected file:" --entry-text="$md5Hash" --width 640;
     else
       echo ""
     fi

--- a/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find Images (recursively)
+++ b/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find Images (recursively)
@@ -38,6 +38,6 @@ if $(zenity --question \
 then
 	rm -rf "$temp_dir"
 fi
-	
+
 exit 0
 

--- a/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find by Content
+++ b/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find by Content
@@ -1,5 +1,6 @@
 #!/bin/bash
 #Find by Content
 #by John Lehr (c) 2009
+#Updated for mate-search-tool
 
-gnome-search-tool --contains="" --path="$(pwd)"
+mate-search-tool --contains="" --path="$(pwd)"

--- a/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find by Name
+++ b/bitcurator/env/.local/share/nautilus/scripts/Find Files/Find by Name
@@ -1,5 +1,6 @@
 #!/bin/bash
 #Find by Content
 #by John Lehr (c) 2009
+#Update for mate-search-tool
 
-gnome-search-tool "$(pwd)"
+mate-search-tool "$(pwd)"

--- a/bitcurator/env/.local/share/nautilus/scripts/Show File Info
+++ b/bitcurator/env/.local/share/nautilus/scripts/Show File Info
@@ -1,3 +1,4 @@
+#!/bin/bash
 for uri in $NAUTILUS_SCRIPT_SELECTED_URIS; do
 fileinfo $uri &
 done

--- a/bitcurator/packages/ccrypt.sls
+++ b/bitcurator/packages/ccrypt.sls
@@ -1,0 +1,2 @@
+ccrypt:
+  pkg.installed

--- a/bitcurator/packages/init.sls
+++ b/bitcurator/packages/init.sls
@@ -10,6 +10,7 @@ include:
   - bitcurator.packages.brasero
   - bitcurator.packages.build-essential
   - bitcurator.packages.bulk-reviewer
+  - bitcurator.packages.ccrypt
   - bitcurator.packages.cdrdao
   - bitcurator.packages.clamav
   - bitcurator.packages.clamav-daemon
@@ -50,6 +51,7 @@ include:
   - bitcurator.packages.hfsutils
   - bitcurator.packages.hfsutils-tcltk
   - bitcurator.packages.icedax
+  - bitcurator.packages.leptonica-progs
   - bitcurator.packages.libafflib-dev
   - bitcurator.packages.libappindicator1
   - bitcurator.packages.libappindicator3-dev
@@ -102,6 +104,7 @@ include:
   - bitcurator.packages.libxml2-utils
   - bitcurator.packages.libxslt1-dev
   - bitcurator.packages.linux-headers-generic
+  - bitcurator.packages.mate-utils
   - bitcurator.packages.mediainfo
   - bitcurator.packages.mencoder
   - bitcurator.packages.mokutil
@@ -163,6 +166,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.brasero
       - sls: bitcurator.packages.build-essential
       - sls: bitcurator.packages.bulk-reviewer
+      - sls: bitcurator.packages.ccrypt
       - sls: bitcurator.packages.cdrdao
       - sls: bitcurator.packages.clamav
       - sls: bitcurator.packages.clamav-daemon
@@ -203,6 +207,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.hfsutils
       - sls: bitcurator.packages.hfsutils-tcltk
       - sls: bitcurator.packages.icedax
+      - sls: bitcurator.packages.leptonica-progs
       - sls: bitcurator.packages.libafflib-dev
       - sls: bitcurator.packages.libappindicator1
       - sls: bitcurator.packages.libappindicator3-dev
@@ -255,6 +260,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.libxml2-utils
       - sls: bitcurator.packages.libxslt1-dev
       - sls: bitcurator.packages.linux-headers-generic
+      - sls: bitcurator.packages.mate-utils
       - sls: bitcurator.packages.mediainfo
       - sls: bitcurator.packages.mencoder
       - sls: bitcurator.packages.mokutil

--- a/bitcurator/packages/leptonica-progs.sls
+++ b/bitcurator/packages/leptonica-progs.sls
@@ -1,0 +1,2 @@
+leptonica-progs:
+  pkg.installed

--- a/bitcurator/packages/mate-utils.sls
+++ b/bitcurator/packages/mate-utils.sls
@@ -1,0 +1,11 @@
+# Name: mate-utils
+# Website: https://github.com/mate-desktop/mate-utils
+# Description: Update of GNOME Utilities, containing mate-search-tool
+# Category: Utilities
+# Author: https://github.com/mate-desktop/mate-utils/blob/master/AUTHORS
+# License: GNU General Public License v2.0 (https://github.com/mate-desktop/mate-utils/blob/master/COPYING)
+# Version: 1.24.0
+# Notes: Includes mate-search-tool
+
+mate-utils:
+  pkg.installed


### PR DESCRIPTION
Based on a recent conversation [in the BitCurator Group](https://groups.google.com/g/bitcurator-users/c/R1l-Z1quEGw/m/YFA4rlQ_BAAJ), this PR will update the Nautilus Scripts to utilize mate-search-tool instead of gnome-search-tool