### PR TITLE
Update siegfried state to account for expired key

### DIFF
--- a/bitcurator/packages/siegfried.sls
+++ b/bitcurator/packages/siegfried.sls
@@ -1,7 +1,26 @@
-include:
-  - bitcurator.repos.siegfried
+# Name: siegfried
+# Website: https://github.com/richardlehane/siegfried
+# Description: Signature-based file format identification
+# Category: 
+# Author: Richard Lehane
+# License: Apache License 2.0 (https://github.com/richardlehane/siegfried/blob/main/LICENSE.txt)
+# Version: 1.11.0
+# Notes: Temporarily installed using deb package
 
-siegfried:
+{% set version = '1.11.0' %}
+{% set hash = '95422e7cb250b4e759187e80a8a35c02ddc09e47bd95cf15c3706837de4983a3' %}
+
+siegfried-pkg-download:
+  file.managed:
+    - name: /tmp/siegfried_{{ version }}-1_amd64.deb
+    - source: https://github.com/richardlehane/siegfried/releases/download/v{{ version }}/siegfried_{{ version }}-1_amd64.deb
+    - source_hash: sha256={{ hash }}
+    - makedirs: True
+
+siegfried-install:
   pkg.installed:
+    - sources:
+      - siegfried: /tmp/siegfried_{{ version }}-1_amd64.deb
     - require:
-      - sls: bitcurator.repos.siegfried
+      - file: siegfried-pkg-download
+

--- a/bitcurator/repos/init.sls
+++ b/bitcurator/repos/init.sls
@@ -3,7 +3,7 @@ include:
   - bitcurator.repos.ubuntu-universe
   - bitcurator.repos.openjdk
   - bitcurator.repos.docker
-  - bitcurator.repos.siegfried
+#  - bitcurator.repos.siegfried
 
 bitcurator-repos:
   test.nop:
@@ -13,4 +13,4 @@ bitcurator-repos:
       - sls: bitcurator.repos.ubuntu-universe
       - sls: bitcurator.repos.openjdk
       - sls: bitcurator.repos.docker
-      - sls: bitcurator.repos.siegfried
+#      - sls: bitcurator.repos.siegfried


### PR DESCRIPTION
Currently the signing key for siegfried is expired (https://github.com/richardlehane/siegfried/issues/249), and as such, it can't be installed through the repo state. This state will install the deb package directly from the github repo to avoid that issue.