### PR TITLE
Fix for current python max recursion error

### DIFF
--- a/.ci/dev-state.sh
+++ b/.ci/dev-state.sh
@@ -3,7 +3,8 @@ echo "salt-call -l debug --local --retcode-passthrough --state-output=mixed stat
 set -x
 
 DISTRO=${DISTRO:="focal"}
+SALT=${SALT:="3006"}
 STATE=$1
 
-docker run -it --rm --name="bitcurator-state-${DISTRO}" -v `pwd`/bitcurator:/srv/salt/bitcurator --cap-add SYS_ADMIN digitalsleuth/bitcurator-tester:${DISTRO} \
+docker run -it --rm --name="bitcurator-state-${DISTRO}" -v `pwd`/bitcurator:/srv/salt/bitcurator --cap-add SYS_ADMIN digitalsleuth/bitcurator-tester:${DISTRO}-${SALT} \
   /bin/bash

--- a/bitcurator/addon.sls
+++ b/bitcurator/addon.sls
@@ -1,7 +1,7 @@
 include:
   - bitcurator.repos
-  - bitcurator.packages
   - bitcurator.python-packages
+  - bitcurator.packages
   - bitcurator.config
   - bitcurator.env
   - bitcurator.tools
@@ -15,8 +15,8 @@ bitcurator-version-file:
     - group: root
     - require:
       - sls: bitcurator.repos
-      - sls: bitcurator.packages
       - sls: bitcurator.python-packages
+      - sls: bitcurator.packages
       - sls: bitcurator.config
       - sls: bitcurator.env
       - sls: bitcurator.tools

--- a/bitcurator/packages/bless.sls
+++ b/bitcurator/packages/bless.sls
@@ -1,2 +1,10 @@
+{% if grains['oscodename'] != 'noble' %}
+
 bless:
   pkg.installed
+
+{% else %}
+bless-not-available-in-noble:
+  test.nop
+
+{% endif %}

--- a/bitcurator/packages/init.sls
+++ b/bitcurator/packages/init.sls
@@ -79,8 +79,7 @@ include:
   - bitcurator.packages.libmad0
   - bitcurator.packages.libmagic-dev
   - bitcurator.packages.libmysqlclient-dev
-  - bitcurator.packages.libncurses5-dev
-  - bitcurator.packages.libncursesw5-dev
+  - bitcurator.packages.libncurses-dev
   - bitcurator.packages.libnss-myhostname
   - bitcurator.packages.libparse-win32registry-perl
   - bitcurator.packages.libpthread-stubs0-dev
@@ -118,6 +117,7 @@ include:
   - bitcurator.packages.plymouth-x11
   - bitcurator.packages.python3
   - bitcurator.packages.python3-dev
+  - bitcurator.packages.python3-icu
   - bitcurator.packages.python3-testresources
   - bitcurator.packages.python3-numpy
   - bitcurator.packages.python3-pip
@@ -236,8 +236,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.libmad0
       - sls: bitcurator.packages.libmagic-dev
       - sls: bitcurator.packages.libmysqlclient-dev
-      - sls: bitcurator.packages.libncurses5-dev
-      - sls: bitcurator.packages.libncursesw5-dev
+      - sls: bitcurator.packages.libncurses-dev
       - sls: bitcurator.packages.libnss-myhostname
       - sls: bitcurator.packages.libparse-win32registry-perl
       - sls: bitcurator.packages.libpthread-stubs0-dev

--- a/bitcurator/packages/libcrypto.sls
+++ b/bitcurator/packages/libcrypto.sls
@@ -10,7 +10,7 @@ libcrypto++8:
 
 {% else %}
 
-libcrypto++8:
+libcrypto++8t64:
   pkg.installed
 
 {% endif %}

--- a/bitcurator/packages/libdvdread.sls
+++ b/bitcurator/packages/libdvdread.sls
@@ -10,7 +10,7 @@ libdvdread8:
 
 {% else %}
 
-libdvdread8
+libdvdread8t64:
   pkg.installed
 
 {% endif %}

--- a/bitcurator/packages/libncurses-dev.sls
+++ b/bitcurator/packages/libncurses-dev.sls
@@ -1,11 +1,14 @@
 {% if grains['oscodename'] != 'noble' %}
 
-libappindicator1:
+libncurses5-dev:
+  pkg.installed
+
+libncursesw5-dev:
   pkg.installed
 
 {% else %}
 
-libappindicator1 is not available in Noble:
-  test.nop
+libncurses-dev:
+  pkg.installed
 
 {% endif %}

--- a/bitcurator/packages/libncurses5-dev.sls
+++ b/bitcurator/packages/libncurses5-dev.sls
@@ -1,2 +1,0 @@
-libncurses5-dev:
-  pkg.installed

--- a/bitcurator/packages/libncursesw5-dev.sls
+++ b/bitcurator/packages/libncursesw5-dev.sls
@@ -1,2 +1,0 @@
-libncursesw5-dev:
-  pkg.installed

--- a/bitcurator/packages/libqt5.sls
+++ b/bitcurator/packages/libqt5.sls
@@ -1,11 +1,21 @@
-libqt5core5a:
-  pkg.installed
+{% if grains['oscodename'] != 'noble' %}
 
-libqt5dbus5:
-  pkg.installed
+libqt5-packages-{{ grains['oscodename'] }}:
+  pkg.installed:
+    - names:
+      - libqt5core5a
+      - libqt5dbus5
+      - libqt5gui5
+      - libqt5widgets5
 
-libqt5gui5:
-  pkg.installed
+{% else %}
 
-libqt5widgets5:
-  pkg.installed
+libqt5-packages-noble:
+  pkg.installed:
+    - names:
+      - libqt5core5t64
+      - libqt5dbus5t64
+      - libqt5gui5t64
+      - libqt5widgets5t64
+
+{% endif %}

--- a/bitcurator/packages/libvte9.sls
+++ b/bitcurator/packages/libvte9.sls
@@ -1,2 +1,11 @@
+{% if grains['oscodename'] != 'noble' %}
+
 libvte9:
   pkg.installed
+
+{% else %}
+
+libvte9t64:
+  pkg.installed
+
+{% endif %}

--- a/bitcurator/packages/python-is-python3.sls
+++ b/bitcurator/packages/python-is-python3.sls
@@ -1,0 +1,2 @@
+python-is-python3:
+  pkg.installed

--- a/bitcurator/packages/python3-icu.sls
+++ b/bitcurator/packages/python3-icu.sls
@@ -1,0 +1,9 @@
+include:
+  - bitcurator.packages.libicu-dev
+  - bitcurator.packages.pkg-config
+
+python3-icu:
+  pkg.installed:
+    - require:
+      - sls: bitcurator.packages.libicu-dev
+      - sls: bitcurator.packages.pkg-config

--- a/bitcurator/python-packages/analyzemft.sls
+++ b/bitcurator/python-packages/analyzemft.sls
@@ -1,9 +1,28 @@
 include:
-  - bitcurator.packages.python3
+  - bitcurator.packages.python3-virtualenv
+
+analyzemft-venv:
+  virtualenv.managed:
+    - name: /opt/analyzemft
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: bitcurator.packages.python3-virtualenv
 
 analyzemft:
   pip.installed:
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/analyzemft/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - virtualenv: analyzemft-venv
+
+analyzemft-symlink:
+  file.symlink:
+    - name: /usr/local/bin/analyzemft
+    - target: /opt/analyzemft/bin/analyzemft
+    - makedirs: False
+    - require:
+      - pip: analyzemft

--- a/bitcurator/python-packages/argparse.sls
+++ b/bitcurator/python-packages/argparse.sls
@@ -1,9 +1,0 @@
-include:
-  - bitcurator.packages.python3
-
-argparse:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - upgrade: True
-    - require:
-      - sls: bitcurator.packages.python3

--- a/bitcurator/python-packages/bagit.sls
+++ b/bitcurator/python-packages/bagit.sls
@@ -1,9 +1,28 @@
 include:
-  - bitcurator.packages.python3
+  - bitcurator.packages.python3-virtualenv
+
+bagit-venv:
+  virtualenv.managed:
+    - name: /opt/bagit
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: bitcurator.packages.python3-virtualenv
 
 bagit:
   pip.installed:
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/bagit/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - virtualenv: bagit-venv
+
+bagit-symlink:
+  file.symlink:
+    - name: /usr/local/bin/bagit
+    - target: /opt/bagit/bin/bagit
+    - makedirs: False
+    - require:
+      - pip: bagit

--- a/bitcurator/python-packages/brunnhilde.sls
+++ b/bitcurator/python-packages/brunnhilde.sls
@@ -1,9 +1,28 @@
 include:
-  - bitcurator.packages.python3
+  - bitcurator.packages.python3-virtualenv
+
+brunnhilde-venv:
+  virtualenv.managed:
+    - name: /opt/brunnhilde
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: bitcurator.packages.python3-virtualenv
 
 brunnhilde:
   pip.installed:
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/brunnhilde/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - virtualenv: brunnhilde-venv
+
+brunnhilde-symlink:
+  file.symlink:
+    - name: /usr/local/bin/brunnhilde
+    - target: /opt/brunnhilde/bin/brunnhilde
+    - makedirs: False
+    - require:
+      - pip: brunnhilde

--- a/bitcurator/python-packages/configobj.sls
+++ b/bitcurator/python-packages/configobj.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 configobj:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install configobj via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/construct.sls
+++ b/bitcurator/python-packages/construct.sls
@@ -1,9 +1,17 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 construct:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install construct via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/dfxml-python.sls
+++ b/bitcurator/python-packages/dfxml-python.sls
@@ -1,12 +1,23 @@
+# Required by identify_filenames.py
+
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
   - bitcurator.packages.git
+  - bitcurator.packages.python-is-python3
+  - bitcurator.python-packages.pip
 
 bitcurator-python-packages-dfxml:
   pip.installed:
     - name: git+https://github.com/dfxml-working-group/dfxml_python.git
     - bin_env: /usr/bin/python3
     - require:
-      - sls: bitcurator.packages.python3
       - sls: bitcurator.packages.git
+      - sls: bitcurator.packages.python-is-python3
+      - sls: bitcurator.python-packages.pip
 
+{% else %}
+Noble requires a virtualenv to install dfxml-python via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/docopt.sls
+++ b/bitcurator/python-packages/docopt.sls
@@ -1,9 +1,17 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 docopt:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install docopt via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/et_xmlfile.sls
+++ b/bitcurator/python-packages/et_xmlfile.sls
@@ -1,9 +1,19 @@
+# Required by identify_filenames.py
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 et_xmlfile:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install et_xmlfile via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/fpdf2.sls
+++ b/bitcurator/python-packages/fpdf2.sls
@@ -1,8 +1,0 @@
-include:
-  - bitcurator.packages.python3
-
-fpdf2:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - require:
-      - sls: bitcurator.packages.python3

--- a/bitcurator/python-packages/init.sls
+++ b/bitcurator/python-packages/init.sls
@@ -1,7 +1,6 @@
 include:
   - bitcurator.python-packages.pip
   - bitcurator.python-packages.analyzemft
-  - bitcurator.python-packages.argparse
   - bitcurator.python-packages.bagit
   - bitcurator.python-packages.brunnhilde
   - bitcurator.python-packages.configobj
@@ -9,15 +8,11 @@ include:
   - bitcurator.python-packages.dfxml-python
   - bitcurator.python-packages.docopt
   - bitcurator.python-packages.et_xmlfile
-  - bitcurator.python-packages.fpdf2
   - bitcurator.python-packages.jdcal
-  - bitcurator.python-packages.lxml
   - bitcurator.python-packages.matplotlib
-  - bitcurator.python-packages.openpyxl
   - bitcurator.python-packages.opf-fido
   - bitcurator.python-packages.path
   - bitcurator.python-packages.pefile
-  - bitcurator.python-packages.pyicu
   - bitcurator.python-packages.python-dateutil
   - bitcurator.python-packages.python-evtx
   - bitcurator.python-packages.python-registry
@@ -34,7 +29,6 @@ bitcurator-python-packages:
     - require:
       - sls: bitcurator.python-packages.pip
       - sls: bitcurator.python-packages.analyzemft
-      - sls: bitcurator.python-packages.argparse
       - sls: bitcurator.python-packages.bagit
       - sls: bitcurator.python-packages.brunnhilde
       - sls: bitcurator.python-packages.configobj
@@ -42,15 +36,11 @@ bitcurator-python-packages:
       - sls: bitcurator.python-packages.dfxml-python
       - sls: bitcurator.python-packages.docopt
       - sls: bitcurator.python-packages.et_xmlfile
-      - sls: bitcurator.python-packages.fpdf2
       - sls: bitcurator.python-packages.jdcal
-      - sls: bitcurator.python-packages.lxml
       - sls: bitcurator.python-packages.matplotlib
-      - sls: bitcurator.python-packages.openpyxl
       - sls: bitcurator.python-packages.opf-fido
       - sls: bitcurator.python-packages.path
       - sls: bitcurator.python-packages.pefile
-      - sls: bitcurator.python-packages.pyicu
       - sls: bitcurator.python-packages.python-dateutil
       - sls: bitcurator.python-packages.python-evtx
       - sls: bitcurator.python-packages.python-registry

--- a/bitcurator/python-packages/jdcal.sls
+++ b/bitcurator/python-packages/jdcal.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 jdcal:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install jdcal via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/jinja2.sls
+++ b/bitcurator/python-packages/jinja2.sls
@@ -1,3 +1,5 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
   - bitcurator.python-packages.pip
 
@@ -6,3 +8,9 @@ jinja2==3.0.3:
     - bin_env: /usr/bin/python3
     - require:
       - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install jinja via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/lxml.sls
+++ b/bitcurator/python-packages/lxml.sls
@@ -1,9 +1,0 @@
-include:
-  - bitcurator.packages.python3
-
-lxml:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - upgrade: True
-    - require:
-      - sls: bitcurator.packages.python3

--- a/bitcurator/python-packages/matplotlib.sls
+++ b/bitcurator/python-packages/matplotlib.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 matplotlib:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install matplotlib via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/openpyxl.sls
+++ b/bitcurator/python-packages/openpyxl.sls
@@ -1,9 +1,0 @@
-include:
-  - bitcurator.packages.python3
-
-openpyxl:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - upgrade: True
-    - require:
-      - sls: bitcurator.packages.python3

--- a/bitcurator/python-packages/opf-fido.sls
+++ b/bitcurator/python-packages/opf-fido.sls
@@ -1,9 +1,28 @@
 include:
-  - bitcurator.packages.python3
+  - bitcurator.packages.python3-virtualenv
+
+opf-fido-venv:
+  virtualenv.managed:
+    - name: /opt/fido
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: bitcurator.packages.python3-virtualenv
 
 opf-fido:
   pip.installed:
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/fido/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - virtualenv: opf-fido-venv
+
+opf-fido-symlink:
+  file.symlink:
+    - name: /usr/local/bin/fido
+    - target: /opt/fido/bin/fido
+    - makedirs: False
+    - require:
+      - pip: opf-fido

--- a/bitcurator/python-packages/path.sls
+++ b/bitcurator/python-packages/path.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 path:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install path via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/pefile.sls
+++ b/bitcurator/python-packages/pefile.sls
@@ -1,9 +1,17 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 pefile:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install pefile via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/pip.sls
+++ b/bitcurator/python-packages/pip.sls
@@ -1,3 +1,5 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
   - bitcurator.packages.python3-pip
 
@@ -8,3 +10,9 @@ bitcurator-python-packages-pip3:
     - upgrade: True
     - require:
       - sls: bitcurator.packages.python3-pip
+
+{% else %}
+Noble requires virtualenvs for python3 package management:
+  test.nop
+
+{% endif %}

--- a/bitcurator/python-packages/pyicu.sls
+++ b/bitcurator/python-packages/pyicu.sls
@@ -1,9 +1,0 @@
-include:
-  - bitcurator.packages.python3
-
-PyICU:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - upgrade: True
-    - require:
-      - sls: bitcurator.packages.python3

--- a/bitcurator/python-packages/python-dateutil.sls
+++ b/bitcurator/python-packages/python-dateutil.sls
@@ -1,9 +1,17 @@
+{% if grains['oscodename'] != 'noble' %}
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 python-dateutil:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install python-dateutil via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/python-evtx.sls
+++ b/bitcurator/python-packages/python-evtx.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 python-evtx:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install python-evtx via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/python-registry.sls
+++ b/bitcurator/python-packages/python-registry.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 python-registry:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install python-registry via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/pytsk3.sls
+++ b/bitcurator/python-packages/pytsk3.sls
@@ -1,9 +1,33 @@
+{% set pytsk_files = ['fsstat','ffind','fls','icat','ifind','ils','istat','blkcat','blkls','blkstat','blkcalc','jcat','jls','mmls','mmstat','mmcat','img_stat','img_cat','disk_sreset','disk_stat','hfind','mactime','sorter','sigfind','tsk_comparedir','tsk_gettimes','tsk_loaddb','tsk_recover'] %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.packages.python3-virtualenv
+
+pytsk3-venv:
+  virtualenv.managed:
+    - name: /opt/pytsk3
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: bitcurator.packages.python3-virtualenv
 
 pytsk3:
   pip.installed:
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/pytsk3/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - virtualenv: pytsk3-venv
+
+{% for file in pytsk_files %}
+pytsk3-symlink-{{ file }}:
+  file.symlink:
+    - name: /usr/local/bin/{{ file }}
+    - target: /opt/pytsk3/bin/{{ file }}
+    - makedirs: False
+    - require:
+      - pip: pytsk3
+
+{% endfor %}

--- a/bitcurator/python-packages/setuptools.sls
+++ b/bitcurator/python-packages/setuptools.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 setuptools:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install setuptools via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/six.sls
+++ b/bitcurator/python-packages/six.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 six:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install six via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/unicodecsv.sls
+++ b/bitcurator/python-packages/unicodecsv.sls
@@ -1,9 +1,18 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 unicodecsv:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install unicodecsv via pip:
+  test.nop
+
+{% endif %}
+

--- a/bitcurator/python-packages/wheel.sls
+++ b/bitcurator/python-packages/wheel.sls
@@ -1,9 +1,17 @@
+{% if grains['oscodename'] != 'noble' %}
+
 include:
-  - bitcurator.packages.python3
+  - bitcurator.python-packages.pip
 
 wheel:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: bitcurator.packages.python3
+      - sls: bitcurator.python-packages.pip
+
+{% else %}
+Noble requires a virtualenv to install wheel via pip:
+  test.nop
+
+{% endif %}

--- a/bitcurator/theme/menu-config/GPG6TI~N
+++ b/bitcurator/theme/menu-config/GPG6TI~N
@@ -1,0 +1,16 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+X-AppInstall-Package=gtkhash
+X-AppInstall-Popcon=815
+X-AppInstall-Section=universe
+
+Name=GtkHash
+Comment=Compute message digests and checksums
+Exec=gtkhash
+Icon=gtkhash
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=Additional Tools
+
+X-Ubuntu-Gettext-Domain=app-install-data


### PR DESCRIPTION
This PR reorders the python and packages states, makes modifications to some core states which wouldn't previously install on Noble (updated versions and version types). It keeps the previous python states which have no include-require at this time for Noble, but sets them to `test.nop` with a notification that a virtualenv is required to install python packages on Noble.

The way forward with virtualenv is to ensure that all python packages are installed with the core package which requires them instead of being installed independently. Those that have actual applications to use have been set up as virtualenvs. Those which do not (at this time) are the ones set to `test.nop`. 

The `identify_filenames.py` script will be updated to reflect a virtualenv and its requirements in an upcoming PR.