### PR TITLE
Add lightgrep

### DIFF
--- a/bitcurator/packages/dh-autoreconf.sls
+++ b/bitcurator/packages/dh-autoreconf.sls
@@ -1,0 +1,3 @@
+bitcurator-package-dh-autoreconf:
+  pkg.installed:
+    - name: dh-autoreconf

--- a/bitcurator/packages/init.sls
+++ b/bitcurator/packages/init.sls
@@ -90,6 +90,7 @@ include:
   - bitcurator.packages.libvte9
   - bitcurator.packages.libxml2-dev
   - bitcurator.packages.libxslt1-dev
+  - bitcurator.packages.lightgrep
   - bitcurator.packages.linux-headers-generic
   - bitcurator.packages.lvm2
   - bitcurator.packages.mate-utils
@@ -239,6 +240,7 @@ bitcurator-packages:
       - sls: bitcurator.packages.libvte9
       - sls: bitcurator.packages.libxml2-dev
       - sls: bitcurator.packages.libxslt1-dev
+      - sls: bitcurator.packages.lightgrep
       - sls: bitcurator.packages.linux-headers-generic
       - sls: bitcurator.packages.lvm2
       - sls: bitcurator.packages.mate-utils

--- a/bitcurator/packages/lightgrep.sls
+++ b/bitcurator/packages/lightgrep.sls
@@ -28,12 +28,22 @@ bitcurator-package-lightgrep-git:
     - require:
       - sls: bitcurator.packages.git
 
+bitcurator-package-lightgrep-modify-example:
+  file.replace:
+    - name: '/usr/local/src/lightgrep/examples/c_example/main.c'
+    - pattern: {{ 'int main(int, char**) {' | regex_escape }}
+    - repl: 'int main(int argv, char** argc) {\n  (void)argv;\n  (void)argc;\n'
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - git: bitcurator-package-lightgrep-git
+
 bitcurator-package-lightgrep-build:
   cmd.run:
     - names:
       - autoreconf -fi
       - ./configure
-      - make -j4
+      - make -j8
       - make install
       - ldconfig
     - cwd: /usr/local/src/lightgrep

--- a/bitcurator/packages/lightgrep.sls
+++ b/bitcurator/packages/lightgrep.sls
@@ -1,0 +1,55 @@
+# Name: lightgrep
+# Website: https://github.com/strozfriedberg/lightgrep
+# Description: Regular Expression engine
+# Category: Utilities
+# Author: Stroz Friedberg LLC
+# License: Apache License 2.0 (https://github.com/strozfriedberg/lightgrep/blob/main/LICENSE.txt)
+# Version: 1.5.0
+# Notes: lightgrep
+
+include:
+  - bitcurator.packages.build-essential
+  - bitcurator.packages.git
+  - bitcurator.packages.pkg-config
+  - bitcurator.packages.dh-autoreconf
+  - bitcurator.packages.libicu-dev
+  - bitcurator.packages.libboost-dev
+  - bitcurator.packages.bison
+  - bitcurator.packages.libboost-program-options-dev
+
+bitcurator-package-lightgrep-git:
+  git.latest:
+    - name: https://github.com/strozfriedberg/lightgrep
+    - target: /usr/local/src/lightgrep
+    - user: root
+    - submodules: True
+    - force_clone: True
+    - force_reset: True
+    - require:
+      - sls: bitcurator.packages.git
+
+bitcurator-package-lightgrep-build:
+  cmd.run:
+    - names:
+      - autoreconf -fi
+      - ./configure
+      - make -j4
+      - make install
+      - ldconfig
+    - cwd: /usr/local/src/lightgrep
+    - require:
+      - git: bitcurator-package-lightgrep-git
+      - sls: bitcurator.packages.build-essential
+      - sls: bitcurator.packages.git
+      - sls: bitcurator.packages.pkg-config
+      - sls: bitcurator.packages.dh-autoreconf
+      - sls: bitcurator.packages.libicu-dev
+      - sls: bitcurator.packages.libboost-dev
+      - sls: bitcurator.packages.bison
+      - sls: bitcurator.packages.libboost-program-options-dev
+
+bitcurator-package-lightgrep-cleanup:
+  file.absent:
+    - name: /usr/local/src/lightgrep
+    - require:
+      - cmd: bitcurator-package-lightgrep-build


### PR DESCRIPTION
This PR will build and install lightgrep. Since the upcoming versions of BE will support building with lightgrep, this will need to be installed prior to building BE with lightgrep.