### PR TITLE
Fixes issue with python-evtx

### DIFF
--- a/.ci/dev-state.sh
+++ b/.ci/dev-state.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-echo "salt-call -l debug --local --retcode-passthrough --state-output=mixed state.sls bitcurator.  pillar='{\"bitcurator_user\": \"bcadmin\"}' --log-file=/saltstack.log --log-file-level=debug --out-file=/saltstack.log --out-file-append"
-set -x
+#set -x
 
-DISTRO=${DISTRO:="focal"}
+DISTRO=${DISTRO:="jammy"}
 SALT=${SALT:="3006"}
 STATE=$1
+echo "salt-call -l debug --local --retcode-passthrough --state-output=mixed state.sls bitcurator.${STATE}  pillar='{\"bitcurator_user\": \"bcadmin\"}' --log-file=/saltstack.log --log-file-level=debug --out-file=/saltstack.log --out-file-append"
 
 docker run -it --rm --name="bitcurator-state-${DISTRO}" -v `pwd`/bitcurator:/srv/salt/bitcurator --cap-add SYS_ADMIN digitalsleuth/bitcurator-tester:${DISTRO}-${SALT} \
   /bin/bash

--- a/bitcurator/python-packages/python-evtx.sls
+++ b/bitcurator/python-packages/python-evtx.sls
@@ -6,7 +6,13 @@
 # License: Apache License 2.0 (https://github.com/williballenthin/python-evtx/blob/master/LICENSE.TXT)
 # Notes: evtx_dump.py, evtx_dump_chunk_slack.py, evtx_dump_json.py, evtx_info.py
 
-{% set files = ['evtx_dump.py','evtx_dump_chunk_slack.py','evtx_dump_json.py','evtx_eid_record_numbers.py','evtx_extract_record.py','evtx_filter_records.py','evtx_info.py','evtx_record_structure.py','evtx_structure.py','evtx_templates.py'] %}
+{% set files = ['evtx_dump','evtx_dump_chunk_slack','evtx_dump_json','evtx_eid_record_numbers','evtx_extract_record','evtx_filter_records','evtx_info','evtx_record_structure','evtx_structure','evtx_templates'] %}
+{% set commit = '1a1357accd3a75524794a6d6dcdec03c09e1660d' %}
+{% if grains['oscodename'] == "jammy" %}
+  {% set pyver = "3.10" %}
+{% elif grains['oscodename'] == "noble" %}
+  {% set pyver = "3.12" %}
+{% endif %}
 
 include:
   - bitcurator.packages.python3-virtualenv
@@ -27,7 +33,7 @@ bitcurator-python-package-python-evtx-venv:
 
 bitcurator-python-package-python-evtx:
   pip.installed:
-    - name: git+https://github.com/williballenthin/python-evtx.git
+    - name: git+https://github.com/williballenthin/python-evtx.git@{{ commit }}
     - bin_env: /opt/python-evtx/bin/python3
     - upgrade: True
     - require:
@@ -35,17 +41,18 @@ bitcurator-python-package-python-evtx:
 
 bitcurator-python-package-python-evtx-import-fix:
   file.replace:
-    - name: /opt/python-evtx/bin/evtx_eid_record_numbers.py
+    - name: /opt/python-evtx/lib/python{{ pyver }}/site-packages/evtx_scripts/evtx_eid_record_numbers.py
     - pattern: 'from filter_records'
-    - repl: 'from evtx_filter_records'
+    - repl: 'from evtx_scripts.evtx_filter_records'
     - count: 1
+    - backup: False
     - require:
       - pip: bitcurator-python-package-python-evtx
 
 {% for file in files %}
 bitcurator-python-package-python-evtx-symlink-{{ file }}:
   file.symlink:
-    - name: /usr/local/bin/{{ file }}
+    - name: /usr/local/bin/{{ file }}.py
     - target: /opt/python-evtx/bin/{{ file }}
     - force: True
     - makedirs: False


### PR DESCRIPTION
There have been recent changes to the installation method of python-evtx (early May) where it has switched from a `setup.py` to a `pyproject.toml`. This means that the scripts which get installed will be installed without .py extensions, unless explicitly defined in the `pyproject.toml`. Additionally, with this update, the scripts were not being installed in their desired location, and ended up failing (see [Issue 94](https://github.com/williballenthin/python-evtx/issues/94)). 

This was recently fixed, but the update has not yet been pushed to PyPi. As such, the pypi version will still fail to install correctly. This PR addresses the recent changes and updates, and pins the current version from the Git repo to 0.8.1 (with patches applied), from the specific commit containing those fixes.

This PR also adds the `.py` extension to the symlink to retain any backwards-compatibility for existing tools and scripts which relied on the installed package having .py extensions.