### PR TITLE
Add Jhove, OpenJDK from Adoptium

### DIFF
--- a/bitcurator/files/auto-install.xml
+++ b/bitcurator/files/auto-install.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/>
+    <com.izforge.izpack.panels.target.TargetPanel id="install_dir">
+        <installpath>/usr/local/src/jhove</installpath>
+    </com.izforge.izpack.panels.target.TargetPanel>
+    <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">
+        <pack index="0" name="JHOVE Application" selected="true"/>
+        <pack index="1" name="JHOVE Shell Scripts" selected="true"/>
+        <pack index="2" name="JHOVE External Modules" selected="true"/>
+    </com.izforge.izpack.panels.packs.PacksPanel>
+    <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+    <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+</AutomatedInstallation>

--- a/bitcurator/packages/init.sls
+++ b/bitcurator/packages/init.sls
@@ -101,7 +101,6 @@ include:
   - bitcurator.packages.mtd-utils
   - bitcurator.packages.mysql-client
   - bitcurator.packages.nwipe
-  - bitcurator.packages.openjdk-8-jdk
   - bitcurator.packages.openssh
   - bitcurator.packages.plymouth-themes
   - bitcurator.packages.plymouth-x11
@@ -251,7 +250,6 @@ bitcurator-packages:
       - sls: bitcurator.packages.mtd-utils
       - sls: bitcurator.packages.mysql-client
       - sls: bitcurator.packages.nwipe
-      - sls: bitcurator.packages.openjdk-8-jdk
       - sls: bitcurator.packages.openssh
       - sls: bitcurator.packages.plymouth-themes
       - sls: bitcurator.packages.plymouth-x11

--- a/bitcurator/packages/openjdk-8-jdk.sls
+++ b/bitcurator/packages/openjdk-8-jdk.sls
@@ -1,2 +1,0 @@
-openjdk-8-jdk:
-  pkg.installed

--- a/bitcurator/packages/openjdk-adoptium.sls
+++ b/bitcurator/packages/openjdk-adoptium.sls
@@ -1,0 +1,15 @@
+# Name: Eclipse Temurin
+# Website: https://adoptium.net/temurin/
+# Description: Open JDK by Adoptium
+# Category: Archival
+# Author: Adoptium
+# License: Eclipse Public License v2 (https://www.eclipse.org/legal/epl-2.0/)
+# Version: 21
+# Notes: 
+
+include:
+  - bitcurator.repos.adoptium
+
+openjdk-adoptium:
+  pkg.installed:
+    - name: temurin-21-jdk

--- a/bitcurator/repos/adoptium.sls
+++ b/bitcurator/repos/adoptium.sls
@@ -1,0 +1,15 @@
+adoptium-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/adoptium.pgp
+    - source: https://packages.adoptium.net/artifactory/api/gpg/key/public
+    - skip_verify: True
+    - makedirs: True
+
+adoptium-repo:
+  pkgrepo.managed:
+    - humanname: Adoptium
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/adoptium.pgp] https://packages.adoptium.net/artifactory/deb {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/adoptium.list
+    - refresh: True
+    - require:
+      - file: adoptium-repo-key

--- a/bitcurator/repos/init.sls
+++ b/bitcurator/repos/init.sls
@@ -1,7 +1,6 @@
 include:
   - bitcurator.repos.ubuntu-multiverse
   - bitcurator.repos.ubuntu-universe
-  - bitcurator.repos.openjdk
   - bitcurator.repos.docker
 #  - bitcurator.repos.siegfried
 
@@ -11,6 +10,5 @@ bitcurator-repos:
     - require:
       - sls: bitcurator.repos.ubuntu-multiverse
       - sls: bitcurator.repos.ubuntu-universe
-      - sls: bitcurator.repos.openjdk
       - sls: bitcurator.repos.docker
 #      - sls: bitcurator.repos.siegfried

--- a/bitcurator/tools/hfsexplorer.sls
+++ b/bitcurator/tools/hfsexplorer.sls
@@ -2,7 +2,7 @@
 {% set hash = '1dfc2183ebcd5f4ca283def3d3a0061542bdbf43d62a1c35208a4b95bf2b9d8e' %}
 
 include:
-  - bitcurator.packages.openjdk-8-jdk
+  - bitcurator.packages.openjdk-adoptium
 
 hfsexplorer-download:
   file.managed:
@@ -25,9 +25,9 @@ hfsexplorer-wrapper:
     - mode: 755
     - contents:
       - '#!/bin/bash'
-      - /usr/share/hfsexplorer/bin/hfsexplorer "$@"
+      - /usr/share/hfsexplorer/bin/hfsexplorer "$@" &
     - require:
-      - sls: bitcurator.packages.openjdk-8-jdk
+      - sls: bitcurator.packages.openjdk-adoptium
 
 hfsexplorer-cleanup:
   file.absent:

--- a/bitcurator/tools/init.sls
+++ b/bitcurator/tools/init.sls
@@ -1,6 +1,7 @@
 include:
   - bitcurator.tools.hfsexplorer
   - bitcurator.tools.dumpfloppy
+  - bitcurator.tools.jhove
   - bitcurator.tools.regripper
   - bitcurator.tools.nsrllookup
   - bitcurator.tools.deark
@@ -11,6 +12,7 @@ bitcurator-tools:
     - require:
       - sls: bitcurator.tools.hfsexplorer
       - sls: bitcurator.tools.dumpfloppy
+      - sls: bitcurator.tools.jhove
       - sls: bitcurator.tools.regripper
       - sls: bitcurator.tools.nsrllookup
       - sls: bitcurator.tools.deark

--- a/bitcurator/tools/jhove.sls
+++ b/bitcurator/tools/jhove.sls
@@ -1,0 +1,57 @@
+# Name: jhove
+# Website: https://jhove.openpreservation.org/
+# Description: JSTOR/Harvard Object Validation Environment - File validation and characterisation
+# Category: Archival
+# Author: Open Preservation Foundation
+# License: GNU Lesser Public License v2.1 (https://github.com/openpreserve/jhove/blob/integration/LICENSE)
+# Version: 1.32.1
+# Notes: Packaged separately for silent unattended installation
+
+{% set version = '1.32.1' %}
+{% set hash = '92c9f95df20b85ae604b61471846d66538482b1671969ec113e3abd75b03b1cd' %}
+
+include:
+  - bitcurator.packages.openjdk-adoptium
+
+jhove-download:
+  file.managed:
+    - name: /tmp/jhove.jar
+    - source: https://software.openpreservation.org/rel/jhove-latest.jar
+    - source_hash: sha256={{ hash }}
+    - makedirs: True
+    - mode: 755
+    - require:
+      - sls: bitcurator.packages.openjdk-adoptium
+
+jhove-auto-install:
+  file.managed:
+    - name: /tmp/auto-install.xml
+    - source: salt://bitcurator/files/auto-install.xml
+    - skip_verify: True
+    - require:
+      - file: jhove-download
+
+jhove-install:
+  cmd.run:
+    - name: /usr/bin/java -jar /tmp/jhove.jar /tmp/auto-install.xml
+    - shell: /bin/bash
+    - require:
+      - file: jhove-auto-install
+
+jhove-cli-symlink:
+  file.symlink:
+    - name: /usr/local/bin/jhove
+    - target: /usr/local/src/jhove/jhove
+    - force: True
+    - makedirs: False
+    - require:
+      - cmd: jhove-install
+
+jhove-gui-symlink:
+  file.symlink:
+    - name: /usr/local/bin/jhove-gui
+    - target: /usr/local/src/jhove/jhove-gui
+    - force: True
+    - makedirs: False
+    - require:
+      - cmd: jhove-install


### PR DESCRIPTION
This PR adds JHOVE and OpenJDK from Adoptium, removes OpenJDK 8, and changes the hfsexplorer state to use the new OpenJDK. It does not add icons or shortcuts at this time.