### PR TITLE
Updated lightgrep to pin to release vs latest git branch

### DIFF
--- a/bitcurator/packages/lightgrep.sls
+++ b/bitcurator/packages/lightgrep.sls
@@ -7,6 +7,9 @@
 # Version: 1.5.0
 # Notes: lightgrep
 
+{% set version = '1.5.0' %}
+{% set hash = 'fe7aa3ed64472b6f57b5048b5584d3df2794507747e5d76213f60c256f8c82fa' %}
+
 include:
   - bitcurator.packages.build-essential
   - bitcurator.packages.git
@@ -17,16 +20,28 @@ include:
   - bitcurator.packages.bison
   - bitcurator.packages.libboost-program-options-dev
 
-bitcurator-package-lightgrep-git:
-  git.latest:
-    - name: https://github.com/strozfriedberg/lightgrep
-    - target: /usr/local/src/lightgrep
-    - user: root
-    - submodules: True
-    - force_clone: True
-    - force_reset: True
+bitcurator-package-lightgrep-download:
+  file.managed:
+    - name: /usr/local/src/files/lightgrep-{{ version }}.tar.gz
+    - source: https://github.com/strozfriedberg/lightgrep/releases/download/{{ version }}/lightgrep-{{ version }}.tar.gz
+    - source_hash: sha256={{ hash }}
+    - makedirs: True
+
+bitcurator-package-lightgrep-extract:
+  archive.extracted:
+    - name: /usr/local/src/
+    - source: /usr/local/src/files/lightgrep-{{ version }}.tar.gz
+    - enforce_toplevel: False
     - require:
-      - sls: bitcurator.packages.git
+      - file: bitcurator-package-lightgrep-download
+
+bitcurator-package-lightgrep-rename:
+  file.rename:
+    - name: /usr/local/src/lightgrep
+    - source: /usr/local/src/lightgrep-{{ version }}
+    - force: True
+    - require:
+      - archive: bitcurator-package-lightgrep-extract
 
 bitcurator-package-lightgrep-build:
   cmd.run:
@@ -38,7 +53,9 @@ bitcurator-package-lightgrep-build:
       - ldconfig
     - cwd: /usr/local/src/lightgrep
     - require:
-      - git: bitcurator-package-lightgrep-git
+      - file: bitcurator-package-lightgrep-download
+      - archive: bitcurator-package-lightgrep-extract
+      - file: bitcurator-package-lightgrep-rename
       - sls: bitcurator.packages.build-essential
       - sls: bitcurator.packages.git
       - sls: bitcurator.packages.pkg-config


### PR DESCRIPTION
This pins the Lightgrep version to the release file instead of the latest git branch, making a consistent installation.